### PR TITLE
Fix read README.md error due to encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r") as fh:


### PR DESCRIPTION
This fix an error where pip install directly from github has an error when `setup.py` is reading `README.md` for descriptions.

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe6 in position 1814: illegal multibyte sequence
```